### PR TITLE
Missing files when uploading sources

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -84,7 +84,7 @@ runs:
       if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
       shell: bash
       run: |
-        tar -czvf source.tar.gz .
+        GLOBIGNORE=".:.." tar -czvf source.tar.gz *
     - name: Upload Source Code
       if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -84,7 +84,7 @@ runs:
       if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
       shell: bash
       run: |
-        tar -czvf source.tar.gz *
+        tar -czvf source.tar.gz .
     - name: Upload Source Code
       if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
       shell: bash


### PR DESCRIPTION
We use a `.ruby-version` file which is needed in the root directory, and the glob pattern doesn't take it