### PR TITLE
Fix missing files, using files from git ls

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -84,7 +84,7 @@ runs:
       if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
       shell: bash
       run: |
-        tar -czvf source.tar.gz *
+        tar -czvf source.tar.gz $(git ls-files)
     - name: Upload Source Code
       if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
       shell: bash


### PR DESCRIPTION
This PR was inspired by #5 (thank you @pierrickouw for helping me realise why my build was failing!), but the suggested fix in #5 gives me this error message:

```
tar: .: file changed as we read it
```

Looking at the logs I can see that `tar` was trying to include the `.git` directory, and other unnecessary files.

Using the list of files from git instead seems like it would correspond better to what the GitHub integration would normally be sending to Heroku—this filters out anything that would be git ignored.