### PR TITLE
Make input default text

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,7 +22,7 @@ inputs:
     required: false
   use-app-json:
     description: "Set up the initial build using app.json. For more info: https://devcenter.heroku.com/articles/setting-up-apps-using-the-heroku-platform-api"
-    default: false
+    default: "false"
     required: false
 outputs:
   url:


### PR DESCRIPTION
Input defaults should be text. The input is correctly treated as text elsewhere in the file.