### PR TITLE
Fix pr-predestroy script not running

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ Earlier version from v1.0 created apps and placed them into the pipeline as a re
 
 In order to utilise the config vars defined for review apps, I decided to use the _/review-apps_ Heroku API endpoint for v2 of this action. There are less things to configure, therefore the inputs are different and caused a breaking change. Both versions are stable and serves different use-cases. Bug fixes will still be treated for both, but with the most focus on v2.
 
-If you use v1.x and want to see the README for v1.x, switch to the v1.x [branch](/tree/v1.x).
+### How to choose?
+
+If you already have review apps enabled for your pipeline, use v2. If you have a pipeline with review apps disabled, use v1.2.x.
+
+If you use v1.x and want to see the README for v1.x, switch to the v1.x [branch](/tree/v1.x). The main branch has code for v2.x.
 
 ## Sponsor
 

--- a/action.yaml
+++ b/action.yaml
@@ -85,7 +85,12 @@ runs:
       if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
       shell: bash
       run: |
-        curl -X DELETE https://api.heroku.com/apps/$APP_NAME \
+        export REVIEW_APP_ID=$(curl -X GET https://api.heroku.com/apps/$APP_NAME/review-app \
+        -H 'Accept: application/vnd.heroku+json; version=3' \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${{ inputs.api-key }}" | \
+        jq -r '.id')
+        curl -X DELETE https://api.heroku.com/review-apps/$REVIEW_APP_ID \
         -H "Content-Type: application/json" \
         -H "Accept: application/vnd.heroku+json; version=3" \
         -H "Authorization: Bearer ${{ inputs.api-key }}"


### PR DESCRIPTION
The pr-predestroy script is normally run when a PR is closed and its
review app is destroyed[1]. In the current release (v2.0.0) it is not
being triggered.

This commit fixes that by calling the /review-apps endpoint instead
of the /apps endpoint to delete the review app.

I have manually tested this change against a repository that I work on,
let me know if you would like some support to replicate the issue!

[1] https://devcenter.heroku.com/articles/github-integration-review-apps#pr-predestroy-script